### PR TITLE
Corrige l'espace parasite qui fait echouer hassfest

### DIFF
--- a/custom_components/atmofrance/translations/en.json
+++ b/custom_components/atmofrance/translations/en.json
@@ -9,7 +9,7 @@
             "user": {
                 "data": {
                     "username": "Username",
-                    "password": "Password "
+                    "password": "Password"
                 },
                 "description": "Enter your Atmo Data credentials.",
                 "title": "Authentication"


### PR DESCRIPTION
Bonjour,

En intégrant atmofrance à mon installation, j'ai fait tourner `hassfest` sur le dépôt et il échoue sur `main` :

```
[ERROR] [TRANSLATIONS] Invalid translations/en.json: the string should not contain
leading or trailing spaces for dictionary value @
data['config']['step']['user']['data']['password']. Got 'Password '
```

Un espace en trop dans le libellé anglais du mot de passe. Un scan de `fr.json` et `pt.json` ne révèle aucun autre cas.

Ça n'a aucun effet visible à l'usage, mais tant que ça échoue, le workflow hassfest ne peut plus servir à détecter autre chose.

J'ai par ailleurs travaillé sur une série de correctifs plus substantiels (gestion d'erreur, cache de token, tests) que je serais heureux de proposer si ça t'intéresse — mais je préférais commencer par quelque chose de minuscule pour ne pas t'imposer une grosse relecture d'entrée de jeu.
