### PR TITLE
Ne plus faire planter la plateforme sensor quand une zone n'a pas de donnees

### DIFF
--- a/custom_components/atmofrance/__init__.py
+++ b/custom_components/atmofrance/__init__.py
@@ -4,6 +4,7 @@ from datetime import timedelta, date
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -55,6 +56,33 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry):
     return True
 
 
+async def _async_resolve_source(entry: ConfigEntry, api, url_code: URL_CODE) -> str | None:
+    """Find which zone code actually returns data for the given indicator.
+
+    Returns CONF_INSEE_CODE (city), CONF_INSEE_EPCI (fallback) or None when
+    neither answers. Must be called once per indicator: a city may be covered
+    for pollution but not for pollen, and vice versa.
+    """
+    databycity = await api.get_data(entry.data[CONF_INSEE_CODE], url_code)
+    if databycity is not None and len(databycity) > 0:
+        # data exist for city, use it
+        _LOGGER.info("Use City code: %s as source", entry.data[CONF_INSEE_CODE])
+        return CONF_INSEE_CODE
+
+    # Get data for EPCI (communauté de communes)
+    databyepci = await api.get_data(entry.data[CONF_INSEE_EPCI], url_code)
+    if databyepci is not None and len(databyepci) > 0:
+        _LOGGER.info("Use EPCI code: %s as source", entry.data[CONF_INSEE_EPCI])
+        return CONF_INSEE_EPCI
+
+    _LOGGER.error(
+        "Impossible de récupérer les données pour la ville %s ou l'EPCI %s",
+        entry.data[CONF_INSEE_CODE],
+        entry.data[CONF_INSEE_EPCI],
+    )
+    return None
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Initialisation from a config entry."""
     _LOGGER.info(
@@ -67,62 +95,39 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     if entry.entry_id not in hass.data[DOMAIN]:
         hass.data[DOMAIN][entry.entry_id] = {}
-        source = None
-        if entry.options[CONF_INCLUDE_POLLUTION] or entry.options[CONF_INCLUDE_POLLUTION_FORECAST]:
-            pollutionapi = AtmoFranceDataApi(entry.data, hass=hass)
-            # Get pollution data for city
-            _LOGGER.info("Getting Pollution data")
-            databycity = await pollutionapi.get_data(entry.data[CONF_INSEE_CODE], URL_CODE.POLLUTION)
-            if (
-                databycity is not None and len(databycity) > 0
-            ):  # data exist for city, use it
-                _LOGGER.info("Use City code: %s as  source",
-                             entry.data[CONF_INSEE_CODE])
-                source = CONF_INSEE_CODE
-            else:  # Get data for EPCI (communauté de commune)
-                databyepci = await pollutionapi.get_data(entry.data[CONF_INSEE_EPCI], URL_CODE.POLLUTION)
-                if databyepci is not None and len(databyepci) > 0:
-                    source = CONF_INSEE_EPCI
-                    _LOGGER.info("Use EPCI code: %s as source",
-                                 entry.data[CONF_INSEE_EPCI])
-                else:
-                    _LOGGER.error(
-                        "Impossible de récupérer les données pour la ville %s ou l'EPCI %s",
-                        entry.data[CONF_INSEE_CODE],
-                        entry.data[CONF_INSEE_EPCI],
+        try:
+            if entry.options[CONF_INCLUDE_POLLUTION] or entry.options[CONF_INCLUDE_POLLUTION_FORECAST]:
+                pollutionapi = AtmoFranceDataApi(entry.data, hass=hass)
+                # Get pollution data for city
+                _LOGGER.info("Getting Pollution data")
+                source = await _async_resolve_source(entry, pollutionapi, URL_CODE.POLLUTION)
+                if source is None:
+                    raise ConfigEntryNotReady(
+                        f"No pollution data available for city {entry.data[CONF_INSEE_CODE]} "
+                        f"nor EPCI {entry.data[CONF_INSEE_EPCI]}"
                     )
-            if not (source is None):
                 hass.data[DOMAIN][entry.entry_id][
                     CONF_POLLUTION_COORDINATOR
                 ] = AtmoFrancePollutionApiCoordinator(hass=hass, config=entry, api=pollutionapi, source=source)
 
-        if entry.options[CONF_INCLUDE_POLLEN] or entry.options[CONF_INCLUDE_POLLEN_FORECAST]:
-            _LOGGER.info("Getting Pollen data")
-            pollenapi = AtmoFranceDataApi(entry.data, hass=hass)
-
-            databycity = await pollenapi.get_data(entry.data[CONF_INSEE_CODE], URL_CODE.POLLEN)
-            if (
-                databycity is not None and len(databycity) > 0
-            ):  # data exist for city, use it
-                _LOGGER.info("Use City code: %s as  source",
-                             entry.data[CONF_INSEE_CODE])
-                source = CONF_INSEE_CODE
-            else:  # Get data for EPCI (communauté de commune)
-                databyepci = await pollenapi.get_data(entry.data[CONF_INSEE_EPCI], URL_CODE.POLLEN)
-                if databyepci is not None and len(databyepci) > 0:
-                    source = CONF_INSEE_EPCI
-                    _LOGGER.info("Use EPCI code: %s as source",
-                                 entry.data[CONF_INSEE_EPCI])
-                else:
-                    _LOGGER.error(
-                        "Impossible de récupérer les données pour la ville %s ou l'EPCI %s",
-                        entry.data[CONF_INSEE_CODE],
-                        entry.data[CONF_INSEE_EPCI],
+            if entry.options[CONF_INCLUDE_POLLEN] or entry.options[CONF_INCLUDE_POLLEN_FORECAST]:
+                _LOGGER.info("Getting Pollen data")
+                pollenapi = AtmoFranceDataApi(entry.data, hass=hass)
+                # `source` is resolved again for pollen: pollution and pollen
+                # zones are independent and must never be inherited.
+                source = await _async_resolve_source(entry, pollenapi, URL_CODE.POLLEN)
+                if source is None:
+                    raise ConfigEntryNotReady(
+                        f"No pollen data available for city {entry.data[CONF_INSEE_CODE]} "
+                        f"nor EPCI {entry.data[CONF_INSEE_EPCI]}"
                     )
-            if not (source is None):
                 hass.data[DOMAIN][entry.entry_id][
                     CONF_POLLEN_COORDINATOR
                 ] = AtmoFrancePollenApiCoordinator(hass=hass, config=entry, api=pollenapi, source=source)
+        except ConfigEntryNotReady:
+            # Drop the partially built entry so the automatic retry rebuilds it
+            hass.data[DOMAIN].pop(entry.entry_id, None)
+            raise
 
     await hass.config_entries.async_forward_entry_setups(entry, [Platform.SENSOR])
 

--- a/custom_components/atmofrance/api.py
+++ b/custom_components/atmofrance/api.py
@@ -84,24 +84,34 @@ class AtmoFranceDataApi:
         try:
             result = await self._session.get(url, headers=headers)
             json = await result.json()
-            _LOGGER.debug("Got response %s ", json)
+        except (ClientError, TimeoutError) as err:
+            _LOGGER.error(
+                "Failed to get data for INSEE %s: %s", insee_code, err)
+            return None
+        _LOGGER.debug("Got response %s ", json)
+        _LOGGER.debug(
+            "Extracting data for INSEE %s and date %s", insee_code, today)
+        features = json.get("features") if isinstance(json, dict) else None
+        if features is None:  # unexpected payload (error page, quota, ...)
+            _LOGGER.error(
+                "Unexpected response from AtmoFrance API for INSEE %s: %s",
+                insee_code,
+                json,
+            )
+            return None
+        if len(features) > 0:  # At least one result
+            self._data = json
             _LOGGER.debug(
-                "Extracting data for INSEE %s and date %s", insee_code, today)
-            if len(json["features"]) > 0:  # At least one result
-                self._data = json
-                _LOGGER.debug(
-                    "Got data for INSEE %s and date > %s: %s",
-                    insee_code,
-                    today,
-                    self._data,
-                )
-            else:  # no result
-                self._data = None
-                _LOGGER.warning(
-                    "No data for INSEE %s and date %s", insee_code, today)
-            return json["features"]
-        except ClientError as err:
-            return err
+                "Got data for INSEE %s and date > %s: %s",
+                insee_code,
+                today,
+                self._data,
+            )
+        else:  # no result
+            self._data = None
+            _LOGGER.warning(
+                "No data for INSEE %s and date %s", insee_code, today)
+        return features
 
     def get_key_value(self, key, shift: int = 0):
         """Get value for the given key in JSON Data for a given date based on shift from today"""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from types import SimpleNamespace
 
 import pytest
+from aiohttp.client import ClientError
 
 from custom_components.atmofrance.api import (
     AtmoFranceDataApi,
@@ -138,3 +139,34 @@ async def test_insee_leve_sur_une_erreur_http():
     api = INSEEAPI(FakeSession(get=Response(500, {})))
     with pytest.raises(ValueError):
         await api.get_data("33000")
+
+
+# --------------------------------------------- erreurs de transport ----
+class FailingSession(FakeSession):
+    """La requête de données lève une erreur réseau."""
+
+    async def get(self, url, headers=None, **kwargs):
+        self.gets += 1
+        raise ClientError("connexion perdue")
+
+
+async def test_une_erreur_reseau_renvoie_none_et_jamais_l_exception():
+    """L'objet exception était retourné, et les appelants faisaient len() dessus."""
+    api = AtmoFranceDataApi(ENTRY_DATA, FailingSession(), hass=FAKE_HASS)
+
+    resultat = await api.get_data("33063", URL_CODE.POLLUTION)
+
+    assert resultat is None
+    assert not isinstance(resultat, Exception)
+
+
+@pytest.mark.parametrize("charge", [
+    "<html>erreur</html>",
+    {"message": "quota depasse"},
+    None,
+])
+async def test_une_charge_utile_inattendue_renvoie_none(charge):
+    """json['features'] levait un KeyError sur une réponse hors format."""
+    api, _ = build(get=Response(200, charge))
+
+    assert await api.get_data("33063", URL_CODE.POLLUTION) is None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -139,3 +139,58 @@ async def test_le_dechargement_libere_l_entree(hass):
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
     assert entry.state is ConfigEntryState.NOT_LOADED
+
+
+# ------------------------------------- absence totale de données ----
+async def test_sans_aucune_donnee_le_setup_demande_une_nouvelle_tentative(hass):
+    """La plateforme sensor plantait sur un KeyError, sans jamais réessayer."""
+    entry = await setup_entry(hass, {}, POLLUTION_ONLY)
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_un_setup_echoue_ne_laisse_rien_derriere_lui(hass):
+    """Sinon la garde sur entry_id ferait sauter la reconstruction."""
+    entry = await setup_entry(hass, {}, POLLUTION_ONLY)
+
+    assert entry.entry_id not in hass.data.get(DOMAIN, {})
+
+
+async def test_la_nouvelle_tentative_aboutit_quand_l_api_repond(hass):
+    entry = await setup_entry(hass, {}, POLLUTION_ONLY)
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+
+    with patch_api({(CITY_CODE, URL_CODE.POLLUTION): FEATURES}):
+        await hass.config_entries.async_reload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+
+
+# ----------------------------------- indépendance pollution / pollen ----
+async def test_le_pollen_n_herite_jamais_de_la_zone_pollution(hass):
+    """La pollution résout sur l'EPCI, le pollen n'a de données nulle part.
+
+    La variable source étant partagée, le pollen réutilisait silencieusement
+    la zone pollution et bâtissait un coordinateur sur une API vide.
+    """
+    entry = await setup_entry(
+        hass, {(EPCI_CODE, URL_CODE.POLLUTION): FEATURES},
+        POLLUTION_AND_POLLEN)
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert CONF_POLLEN_COORDINATOR not in coordinators(hass, entry)
+
+
+async def test_chaque_indicateur_resout_sa_propre_zone(hass):
+    """La pollution n'est couverte que par l'EPCI, le pollen que par la commune."""
+    coverage = {
+        (EPCI_CODE, URL_CODE.POLLUTION): FEATURES,
+        (CITY_CODE, URL_CODE.POLLEN): FEATURES,
+    }
+    entry = await setup_entry(hass, coverage, POLLUTION_AND_POLLEN)
+    construits = coordinators(hass, entry)
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert construits[CONF_POLLUTION_COORDINATOR]._source == CONF_INSEE_EPCI
+    assert construits[CONF_POLLEN_COORDINATOR]._source == CONF_INSEE_CODE


### PR DESCRIPTION
Closes #52
Closes #46
Closes #53

Maintenant que #57 est mergée, cette PR arrive **avec ses tests**, comme annoncé : ils échouent sur `main`, ils passent avec le correctif.

```
sans le correctif :   8 failed, 42 passed
avec le correctif :  50 passed
```

## Le bug

Quand ni la commune ni son EPCI ne renvoient de données, aucun coordinateur n'est construit — mais `async_forward_entry_setups` est appelé quand même, et la plateforme meurt en lisant une clé jamais posée.

Le point que les tests ont rendu visible, et que je n'avais pas bien formulé dans #52 : **l'entrée ne se signale pas en erreur, elle se déclare `LOADED`**. Home Assistant absorbe l'échec de la plateforme, et l'utilisateur se retrouve avec une intégration qui se dit chargée et un appareil vide. C'est pour ça que le diagnostic est difficile côté utilisateur.

```
assert <ConfigEntryState.LOADED> is <ConfigEntryState.SETUP_RETRY>
```

Rien ne retente ensuite. Les entités restent absentes jusqu'à un redémarrage manuel — d'où le fait que dans #46, « the only fix is: patience » ne fonctionne pas : quand Atmo republie, l'intégration ne s'en aperçoit pas.

Lever `ConfigEntryNotReady` rend la main à Home Assistant, qui retente avec backoff et reconstruit dès que les données reviennent.

Une subtilité que ça demande : `hass.data[DOMAIN][entry.entry_id] = {}` est écrit **avant** tout appel réseau, et le bloc est gardé par `if entry_id not in hass.data[DOMAIN]`. En l'état, la première nouvelle tentative sauterait la reconstruction et retomberait au même endroit. Le test le verrouille :

```
assert '01KYWFS...' not in {'01KYWFS...': {}}
```

## Deux correctifs viennent avec

Pas par goût du lot : corriger le crash sans eux ne fait que le déplacer.

**`get_data` retournait l'objet `ClientError`** au lieu de lever ou de retourner `None`. Les appelants exécutent `len()` dessus et font tomber le setup par un `TypeError` — le même symptôme, par un autre chemin.

```
assert ClientError('connexion perdue') is None
```

Une charge utile hors format cassait aussi de trois façons différentes, selon ce que renvoie le serveur :

```
TypeError: string indices must be integers        (page HTML d'erreur)
KeyError: 'features'                              (message de quota)
TypeError: 'NoneType' object is not subscriptable (corps vide)
```

**La variable `source` était partagée** entre les blocs pollution et pollen. Initialisée une seule fois avant le bloc pollution, elle conserve cette valeur si le pollen n'a de données nulle part — et un coordinateur pollen est bâti sur une API qui n'en contient pas. Les capteurs affichent « Indisponible » indéfiniment, sans la moindre erreur. La résolution passe dans `_async_resolve_source` et se refait par indicateur.

## Portée

2 fichiers de code, ~80 lignes, plus 9 tests. Rien qui touche aux entités, aux traductions ou au parcours de configuration.

## Note

Les workflows du dépôt sont désactivés par GitHub pour inactivité (voir plus bas), donc aucun check n'apparaîtra ici tant que ce n'est pas réactivé. Les chiffres ci-dessus viennent de cette branche exactement, exécutée sur mon fork.
