### PR TITLE
Ajoute une suite de tests et l'execute en CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,22 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements_test.txt
+      - name: Run tests
+        run: pytest -q

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+testpaths = tests
+pythonpath = .
+asyncio_mode = auto
+norecursedirs = .git custom_components/atmofrance

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,1 @@
+pytest-homeassistant-custom-component

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,5 @@
+"""Tests for the atmofrance integration.
+
+This file matters: without it pytest puts tests/ on sys.path instead of the
+repository root, and custom_components stops being importable.
+"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Shared fixtures for the atmofrance test suite."""
+import pytest
+
+pytest_plugins = "pytest_homeassistant_custom_component"
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Let Home Assistant load custom_components/atmofrance in every test."""
+    yield

--- a/tests/const.py
+++ b/tests/const.py
@@ -1,0 +1,56 @@
+"""Fixtures shared by the atmofrance tests."""
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+
+from custom_components.atmofrance.const import (
+    CONF_CITY,
+    CONF_INCLUDE_POLLEN,
+    CONF_INCLUDE_POLLEN_FORECAST,
+    CONF_INCLUDE_POLLUTION,
+    CONF_INCLUDE_POLLUTION_FORECAST,
+    CONF_INSEE_CODE,
+    CONF_INSEE_EPCI,
+)
+
+CITY_CODE = "33063"
+EPCI_CODE = "243300316"
+
+ENTRY_DATA = {
+    CONF_USERNAME: "user@example.com",
+    CONF_PASSWORD: "hunter2",
+    CONF_INSEE_CODE: CITY_CODE,
+    CONF_INSEE_EPCI: EPCI_CODE,
+    CONF_CITY: "Bordeaux",
+}
+
+POLLUTION_ONLY = {
+    CONF_INCLUDE_POLLUTION: True,
+    CONF_INCLUDE_POLLEN: False,
+    CONF_INCLUDE_POLLUTION_FORECAST: False,
+    CONF_INCLUDE_POLLEN_FORECAST: False,
+}
+
+POLLUTION_AND_POLLEN = {
+    CONF_INCLUDE_POLLUTION: True,
+    CONF_INCLUDE_POLLEN: True,
+    CONF_INCLUDE_POLLUTION_FORECAST: False,
+    CONF_INCLUDE_POLLEN_FORECAST: False,
+}
+
+
+def feature(date_ech, **properties):
+    """Build one GeoJSON feature as the Atmo France API returns it."""
+    props = {
+        "date_ech": date_ech,
+        "source": "ATMO Nouvelle-Aquitaine",
+        "date_maj": f"{date_ech} 09:00:00",
+        "type_zone": "commune",
+        "lib_zone": "Bordeaux",
+        "code_qual": 2,
+        "code_no2": 1,
+        "code_o3": 2,
+        "code_pm10": 2,
+        "code_pm25": 3,
+        "code_so2": 1,
+    }
+    props.update(properties)
+    return {"properties": props}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,140 @@
+"""Tests unitaires de AtmoFranceDataApi.
+
+La session HTTP est simulée plutôt que mockée au niveau du transport : ces
+tests portent sur le comportement de l'API, pas sur le format de la requête.
+"""
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.atmofrance.api import (
+    AtmoFranceDataApi,
+    INSEEAPI,
+    TooManyRequestsError,
+)
+from custom_components.atmofrance.const import URL_CODE
+
+from .const import ENTRY_DATA, feature
+
+FAKE_HASS = SimpleNamespace(config=SimpleNamespace(time_zone="Europe/Paris"))
+TODAY = datetime.now().strftime("%Y-%m-%d")
+
+
+class Response:
+    def __init__(self, status, body, headers=None):
+        self.status = status
+        self._body = body
+        self.headers = headers or {}
+
+    async def json(self):
+        return self._body
+
+
+class FakeSession:
+    def __init__(self, login=None, get=None):
+        self._login = login or Response(200, {"token": "un-token"})
+        self._get = get or Response(200, {"features": [feature(TODAY)]})
+        self.posts = 0
+        self.gets = 0
+
+    async def post(self, url, json=None, **kwargs):
+        self.posts += 1
+        return self._login
+
+    async def get(self, url, headers=None, **kwargs):
+        self.gets += 1
+        return self._get
+
+
+def build(login=None, get=None):
+    session = FakeSession(login, get)
+    return AtmoFranceDataApi(ENTRY_DATA, session, hass=FAKE_HASS), session
+
+
+# ----------------------------------------------------- authentification ----
+async def test_le_token_est_recupere_et_conserve():
+    api, session = build()
+    await api.async_get_token()
+    assert api._token == "un-token"
+    assert session.posts == 1
+
+
+async def test_un_429_leve_too_many_requests():
+    api, _ = build(login=Response(429, {}, {"Retry-After": "60"}))
+    with pytest.raises(TooManyRequestsError):
+        await api.async_get_token()
+
+
+@pytest.mark.parametrize("status", [401, 403, 500, 503])
+async def test_un_login_refuse_leve_connection_refused(status):
+    api, _ = build(login=Response(status, {}))
+    with pytest.raises(ConnectionRefusedError):
+        await api.async_get_token()
+
+
+# ------------------------------------------------ recuperation des donnees ----
+async def test_une_reponse_nominale_renvoie_les_features():
+    api, _ = build()
+    data = await api.get_data("33063", URL_CODE.POLLUTION)
+    assert isinstance(data, list)
+    assert len(data) == 1
+
+
+async def test_les_metadonnees_sont_exposees():
+    api, _ = build()
+    await api.get_data("33063", URL_CODE.POLLUTION)
+    assert api.source == "ATMO Nouvelle-Aquitaine"
+    assert api.nom_zone == "Bordeaux"
+    assert api.type_zone == "commune"
+    assert api.last_update
+
+
+async def test_un_jeu_de_resultats_vide_renvoie_une_liste_vide():
+    api, _ = build(get=Response(200, {"features": []}))
+    assert await api.get_data("33063", URL_CODE.POLLUTION) == []
+
+
+async def test_les_metadonnees_sont_vides_avant_toute_requete():
+    api, _ = build()
+    assert api.source == ""
+    assert api.nom_zone == ""
+
+
+# ------------------------------------------------------- get_key_value ----
+async def test_get_key_value_lit_la_valeur_du_jour():
+    api, _ = build()
+    await api.get_data("33063", URL_CODE.POLLUTION)
+    assert api.get_key_value("code_pm10") == 2
+    assert api.get_key_value("code_qual") == 2
+
+
+async def test_get_key_value_renvoie_vide_pour_une_date_absente():
+    """Le J+1 n'est publie qu'en cours de journee."""
+    api, _ = build()
+    await api.get_data("33063", URL_CODE.POLLUTION)
+    assert api.get_key_value("code_pm10", 1) == ""
+
+
+async def test_get_key_value_renvoie_vide_sans_donnees():
+    api, _ = build()
+    assert api.get_key_value("code_pm10") == ""
+
+
+# --------------------------------------------------------------- INSEE ----
+async def test_insee_renvoie_les_communes():
+    communes = [{"code": "33063", "nom": "Bordeaux", "codeEpci": "243300316"}]
+    api = INSEEAPI(FakeSession(get=Response(200, communes)))
+    assert await api.get_data("33000") == communes
+
+
+async def test_insee_leve_sur_un_code_postal_inconnu():
+    api = INSEEAPI(FakeSession(get=Response(200, [])))
+    with pytest.raises(ValueError):
+        await api.get_data("00000")
+
+
+async def test_insee_leve_sur_une_erreur_http():
+    api = INSEEAPI(FakeSession(get=Response(500, {})))
+    with pytest.raises(ValueError):
+        await api.get_data("33000")

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,114 @@
+"""Tests du parcours de configuration."""
+from unittest.mock import patch
+
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.data_entry_flow import FlowResultType
+
+from custom_components.atmofrance.const import (
+    CONF_CODE_POSTAL,
+    CONF_INCLUDE_POLLEN,
+    CONF_INCLUDE_POLLUTION,
+    DOMAIN,
+)
+
+CREDENTIALS = {CONF_USERNAME: "utilisateur", CONF_PASSWORD: "motdepasse"}
+BORDEAUX = [{"code": "33063", "nom": "Bordeaux", "codeEpci": "243300316"}]
+GIRONDE = BORDEAUX + [
+    {"code": "33281", "nom": "Merignac", "codeEpci": "243300316"}]
+
+
+def patch_token():
+    return patch(
+        "custom_components.atmofrance.config_flow."
+        "AtmoFranceDataApi.async_get_token")
+
+
+def patch_insee(communes=BORDEAUX):
+    return patch(
+        "custom_components.atmofrance.config_flow.INSEEAPI.get_data",
+        return_value=communes)
+
+
+async def start(hass):
+    return await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER})
+
+
+async def jusqu_aux_indicateurs(hass, communes=BORDEAUX):
+    """Déroule authentification puis code postal."""
+    result = await start(hass)
+    with patch_token():
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], CREDENTIALS)
+    with patch_insee(communes):
+        return await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_CODE_POSTAL: "33000"})
+
+
+# ------------------------------------------------------ enchaînement ----
+async def test_le_parcours_demarre_sur_l_authentification(hass):
+    result = await start(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+
+async def test_des_identifiants_valides_menent_a_la_localisation(hass):
+    result = await start(hass)
+    with patch_token():
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], CREDENTIALS)
+
+    assert result["step_id"] == "location"
+
+
+async def test_un_code_postal_a_une_commune_saute_la_selection(hass):
+    result = await jusqu_aux_indicateurs(hass)
+
+    assert result["step_id"] == "sensors_type"
+
+
+async def test_plusieurs_communes_ouvrent_la_selection(hass):
+    result = await jusqu_aux_indicateurs(hass, GIRONDE)
+
+    assert result["step_id"] == "multilocation"
+
+
+# --------------------------------------------------------- création ----
+async def test_le_parcours_complet_cree_une_entree(hass):
+    result = await jusqu_aux_indicateurs(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_INCLUDE_POLLUTION: True})
+    assert result["step_id"] == "forecast_sensor_type"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {})
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"]["INSEE"] == "33063"
+    assert result["data"]["INSEE EPCI"] == "243300316"
+    assert result["data"]["city"] == "Bordeaux"
+    assert result["options"][CONF_INCLUDE_POLLUTION] is True
+    assert result["options"][CONF_INCLUDE_POLLEN] is False
+
+
+async def test_le_titre_de_l_entree_porte_la_commune(hass):
+    result = await jusqu_aux_indicateurs(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_INCLUDE_POLLEN: True})
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {})
+
+    assert "Bordeaux" in result["title"]
+
+
+async def test_aucun_indicateur_selectionne_est_refuse(hass):
+    result = await jusqu_aux_indicateurs(hass)
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {})
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "need_one_option"}

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,141 @@
+"""Tests de mise en place de l'entrée de configuration."""
+from unittest.mock import patch
+
+from homeassistant.config_entries import ConfigEntryState
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.atmofrance.const import (
+    CONF_INSEE_CODE,
+    CONF_INSEE_EPCI,
+    CONF_POLLEN_COORDINATOR,
+    CONF_POLLUTION_COORDINATOR,
+    DOMAIN,
+    URL_CODE,
+)
+
+from .const import (
+    CITY_CODE,
+    ENTRY_DATA,
+    EPCI_CODE,
+    POLLUTION_AND_POLLEN,
+    POLLUTION_ONLY,
+    feature,
+)
+
+FEATURES = [feature("2026-07-30")]
+
+
+class FakeApi:
+    """Remplace AtmoFranceDataApi, piloté par une table de couverture."""
+
+    def __init__(self, coverage):
+        self._coverage = coverage
+        self.calls = []
+
+    async def get_data(self, code, url_code):
+        self.calls.append((code, url_code))
+        return self._coverage.get((code, url_code))
+
+    def get_key_value(self, key, shift=0):
+        return 2
+
+    source = "ATMO Nouvelle-Aquitaine"
+    last_update = "2026-07-30 09:00:00"
+    type_zone = "commune"
+    nom_zone = "Bordeaux"
+
+
+def patch_api(coverage):
+    return patch(
+        "custom_components.atmofrance.AtmoFranceDataApi",
+        side_effect=lambda *args, **kwargs: FakeApi(coverage),
+    )
+
+
+async def setup_entry(hass, coverage, options):
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=ENTRY_DATA, options=options, version=3)
+    entry.add_to_hass(hass)
+    with patch_api(coverage):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+def coordinators(hass, entry):
+    return hass.data.get(DOMAIN, {}).get(entry.entry_id, {})
+
+
+# --------------------------------------------------- résolution de zone ----
+async def test_les_donnees_de_la_commune_sont_prioritaires(hass):
+    entry = await setup_entry(
+        hass, {(CITY_CODE, URL_CODE.POLLUTION): FEATURES}, POLLUTION_ONLY)
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert coordinators(hass, entry)[
+        CONF_POLLUTION_COORDINATOR]._source == CONF_INSEE_CODE
+
+
+async def test_repli_sur_l_epci_sans_donnees_communales(hass):
+    entry = await setup_entry(
+        hass, {(EPCI_CODE, URL_CODE.POLLUTION): FEATURES}, POLLUTION_ONLY)
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert coordinators(hass, entry)[
+        CONF_POLLUTION_COORDINATOR]._source == CONF_INSEE_EPCI
+
+
+async def test_la_commune_est_interrogee_avant_l_epci(hass):
+    entry = await setup_entry(
+        hass, {(EPCI_CODE, URL_CODE.POLLUTION): FEATURES}, POLLUTION_ONLY)
+    api = coordinators(hass, entry)[CONF_POLLUTION_COORDINATOR].api
+
+    assert api.calls[0][0] == CITY_CODE
+    assert api.calls[1][0] == EPCI_CODE
+
+
+# ------------------------------------------------------ coordinateurs ----
+async def test_un_coordinateur_par_indicateur_active(hass):
+    coverage = {
+        (CITY_CODE, URL_CODE.POLLUTION): FEATURES,
+        (CITY_CODE, URL_CODE.POLLEN): FEATURES,
+    }
+    entry = await setup_entry(hass, coverage, POLLUTION_AND_POLLEN)
+    construits = coordinators(hass, entry)
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert CONF_POLLUTION_COORDINATOR in construits
+    assert CONF_POLLEN_COORDINATOR in construits
+
+
+async def test_aucun_coordinateur_pollen_si_l_option_est_absente(hass):
+    entry = await setup_entry(
+        hass, {(CITY_CODE, URL_CODE.POLLUTION): FEATURES}, POLLUTION_ONLY)
+
+    assert CONF_POLLEN_COORDINATOR not in coordinators(hass, entry)
+
+
+async def test_le_coordinateur_interroge_le_bon_flux(hass):
+    entry = await setup_entry(
+        hass, {(CITY_CODE, URL_CODE.POLLUTION): FEATURES}, POLLUTION_ONLY)
+    api = coordinators(hass, entry)[CONF_POLLUTION_COORDINATOR].api
+
+    assert all(appel[1] is URL_CODE.POLLUTION for appel in api.calls)
+
+
+# ------------------------------------------------------------ entités ----
+async def test_les_capteurs_de_pollution_sont_crees(hass):
+    await setup_entry(
+        hass, {(CITY_CODE, URL_CODE.POLLUTION): FEATURES}, POLLUTION_ONLY)
+
+    assert len(hass.states.async_all("sensor")) == 6
+
+
+# ---------------------------------------------------------- unload ----
+async def test_le_dechargement_libere_l_entree(hass):
+    entry = await setup_entry(
+        hass, {(CITY_CODE, URL_CODE.POLLUTION): FEATURES}, POLLUTION_ONLY)
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,118 @@
+"""Tests des entites capteur."""
+import logging
+
+import pytest
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.atmofrance.const import (
+    DOMAIN,
+    POLLEN_ALERT_SENSORS,
+    POLLEN_CONC_SENSORS,
+    POLLUTION_LEVEL,
+    POLLUTION_SENSORS,
+)
+from custom_components.atmofrance.sensor import (
+    AtmoFrancePollenConcentrationEntity,
+    AtmoFrancePollenLevelEntity,
+    AtmoFrancePollutionEntity,
+)
+
+from .const import ENTRY_DATA, POLLUTION_ONLY
+
+_LOGGER = logging.getLogger(__name__)
+
+PM10 = next(d for d in POLLUTION_SENSORS if d.key == "code_pm10")
+AMBROISIE = next(d for d in POLLEN_ALERT_SENSORS if d.key == "code_ambr")
+CONC_GRAM = next(d for d in POLLEN_CONC_SENSORS if d.key == "conc_gram")
+
+
+class StubApi:
+    """Renvoie ce qu'on lui a demande de renvoyer."""
+
+    def __init__(self, values):
+        self._values = values
+
+    def get_key_value(self, key, shift=0):
+        return self._values.get((key, shift), "")
+
+    source = "ATMO Nouvelle-Aquitaine"
+    last_update = "2026-07-30 09:00:00"
+    type_zone = "commune"
+    nom_zone = "Bordeaux"
+
+
+def make_entity(hass, entity_class, description, values, shift=0):
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=ENTRY_DATA, options=POLLUTION_ONLY, version=3)
+    entry.add_to_hass(hass)
+    coordinator = DataUpdateCoordinator(
+        hass, _LOGGER, name="test", config_entry=entry)
+    coordinator.api = StubApi(values)
+    return entity_class(hass, entry, description, coordinator, shift)
+
+
+# ------------------------------------------------------ valeurs lues ----
+@pytest.mark.parametrize("raw", [2, "2", 2.0])
+async def test_un_niveau_de_pollution_est_converti_en_entier(hass, raw):
+    entity = make_entity(
+        hass, AtmoFrancePollutionEntity, PM10, {("code_pm10", 0): raw})
+    assert entity.native_value == 2
+
+
+async def test_un_niveau_de_pollen_flottant_est_converti_en_entier(hass):
+    """L'API renvoie les niveaux de pollen en flottants : code_gram = 2.0."""
+    entity = make_entity(
+        hass, AtmoFrancePollenLevelEntity, AMBROISIE, {("code_ambr", 0): 3.0})
+    assert entity.native_value == 3
+
+
+async def test_une_concentration_garde_sa_precision(hass):
+    entity = make_entity(
+        hass, AtmoFrancePollenConcentrationEntity, CONC_GRAM,
+        {("conc_gram", 0): 8.2})
+    assert entity.native_value == 8.2
+
+
+# --------------------------------------------------------- attributs ----
+async def test_les_attributs_traduisent_le_niveau(hass):
+    entity = make_entity(
+        hass, AtmoFrancePollutionEntity, PM10, {("code_pm10", 0): 4})
+
+    attributs = entity.extra_state_attributes
+
+    assert attributs["Libellé"] == POLLUTION_LEVEL[4]
+    assert attributs["Couleur"] == "#ff5050"
+    assert attributs["Nom de la zone"] == "Bordeaux"
+    assert attributs["Type de zone"] == "commune"
+
+
+# --------------------------------------------------- identite entites ----
+async def test_une_entite_de_prevision_est_distincte_du_jour(hass):
+    aujourdhui = make_entity(
+        hass, AtmoFrancePollutionEntity, PM10, {("code_pm10", 0): 2})
+    demain = make_entity(
+        hass, AtmoFrancePollutionEntity, PM10, {("code_pm10", 1): 3}, shift=1)
+
+    assert aujourdhui._attr_unique_id != demain._attr_unique_id
+    assert aujourdhui._attr_name != demain._attr_name
+    assert demain._attr_name.endswith("J+1")
+
+
+async def test_le_decalage_selectionne_le_bon_jour(hass):
+    entity = make_entity(
+        hass, AtmoFrancePollutionEntity, PM10,
+        {("code_pm10", 0): 2, ("code_pm10", 1): 5}, shift=1)
+    assert entity.native_value == 5
+
+
+async def test_le_nom_porte_le_libelle_du_capteur(hass):
+    entity = make_entity(hass, AtmoFrancePollutionEntity, PM10, {})
+    assert PM10.name in entity._attr_name
+
+
+async def test_l_appareil_est_un_service_attribue_a_atmo(hass):
+    entity = make_entity(hass, AtmoFrancePollutionEntity, PM10, {})
+
+    assert entity._attr_device_info["model"] == "Atmo France API"
+    assert "Atmo France" in entity._attr_attribution


### PR DESCRIPTION
Comme demandé, on commence par les tests. Premier lot de la série thématique.

**41 tests, tous verts contre `main` tel quel.** Aucune ligne de `custom_components/` n'est touchée : uniquement `tests/`, la configuration pytest et un workflow.

## Le principe retenu

J'ai délibérément **exclu tout test qui affirmerait un comportement que je proposerai de changer ensuite**. Une suite qui fige les particularités actuelles rendrait chaque correctif suivant plus difficile à faire passer — il faudrait modifier les tests en même temps que le code, ce qui est exactement ce qu'on veut éviter.

Concrètement, ce qui est couvert ici est ce qui est **déjà correct** :

| Fichier | Couverture |
|---|---|
| `test_api.py` | authentification, `TooManyRequestsError` sur 429, récupération nominale, métadonnées, `get_key_value`, résolution INSEE |
| `test_init.py` | résolution commune → EPCI, création des coordinateurs par indicateur, création des entités, déchargement |
| `test_config_flow.py` | enchaînement des étapes, sélection multi-communes, création de l'entrée, refus si aucun indicateur |
| `test_sensor.py` | conversion des niveaux, précision des concentrations, attributs, identité des entités de prévision |

Ce que je proposerai plus tard viendra **avec ses propres tests**, qui échoueront avant le correctif et passeront après. C'est ce qui rend une correction vérifiable plutôt que déclarative.

## Détails techniques

`AtmoFranceDataApi` est substituée plutôt que mockée au niveau HTTP : ces tests portent sur le comportement, pas sur le format de requête. Ça les rend insensibles à un changement d'URL ou d'encodage.

`tests/__init__.py` n'est pas décoratif : sans lui, pytest place `tests/` dans `sys.path` au lieu de la racine et `custom_components` devient introuvable.

`requirements_test.txt` n'est volontairement pas épinglé. La suite suit donc la dernière version de Home Assistant, ce qui lui permet d'attraper une dépréciation avant qu'elle ne casse une installation. `workflow_dispatch` est là pour pouvoir la lancer à la main après une montée de version HA.

## Note

Les workflows du dépôt sont désactivés par GitHub pour inactivité (voir #56), donc les checks n'apparaîtront pas tant que ce n'est pas réactivé. La suite est verte, je l'ai fait tourner sur mon fork depuis cette branche exactement.

## Suite proposée

Dans l'ordre que tu voudras :

1. **plantage du setup** — c'est #56, déjà ouverte, qui ferme #52, #46 et #53
2. **config flow** — les erreurs d'authentification ne remontent pas à l'utilisateur
3. **robustesse réseau** — session non fermée, ré-authentification à chaque requête
4. **pannes silencieuses** — les capteurs servent des valeurs périmées sans signal
5. **valeurs manquantes** — forcées à `0` et enregistrées comme des mesures
6. **re-authentification** — absente aujourd'hui

Dis-moi par quoi tu veux continuer.
